### PR TITLE
Attempt to solve dist issue in npm registry with new version

### DIFF
--- a/packages/networks/package.json
+++ b/packages/networks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holographxyz/networks",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Holograph Protocol",
   "license": "SEE LICENSE IN LICENSE.md",
   "author": "@holographxyz",


### PR DESCRIPTION
## Describe Changes

Changes made to the package: **networks**.

Seems like dist folder wasn't included in the latest publish to npm registry. Might be related to npm vs pnpm
Bumping version so we can try to republish 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] All tests are passing
