### PR TITLE
Feature / HOLO 1395 add Bridge NFT class to SDK

### DIFF
--- a/packages/sdk/src/assets/bridge-nft.ts
+++ b/packages/sdk/src/assets/bridge-nft.ts
@@ -1,0 +1,90 @@
+import {Address, Hex, Transaction, encodeAbiParameters, hexToBigInt, parseAbiParameters, zeroAddress} from 'viem'
+
+import {BridgeAsset} from './bridge-asset'
+import {HolographLogger, HolographWallet} from '../services'
+import {BridgeNftInput, HolographConfig} from '../utils/types'
+
+export class BridgeNft extends BridgeAsset {
+  private _initCode: Hex | undefined
+
+  constructor(
+    configObject: HolographConfig,
+    private readonly _bridgeNftInput: BridgeNftInput,
+    gasSettings?: {sourceGasPrice: bigint; sourceGasLimit: bigint},
+  ) {
+    const _logger = HolographLogger.createLogger({className: BridgeNft.name})
+    super(configObject, _logger, gasSettings)
+  }
+
+  get contractAddress() {
+    return this._bridgeNftInput.contractAddress
+  }
+
+  get tokenId() {
+    return this._bridgeNftInput.tokenId
+  }
+
+  get from() {
+    return this._bridgeNftInput.from
+  }
+
+  get destinationChainId() {
+    return this._bridgeNftInput.destinationChainId
+  }
+
+  get sourceChainId() {
+    return this._bridgeNftInput.sourceChainId
+  }
+
+  static async createInitCode(from: Address, to: Address, tokenId: Hex): Promise<Hex> {
+    const initCode = encodeAbiParameters(parseAbiParameters('address, address, uint256'), [
+      from,
+      to,
+      hexToBigInt(tokenId, {size: 32}),
+    ])
+
+    return initCode
+  }
+
+  async getInitCode() {
+    const logger = this._logger.addContext({functionName: this.bridgeOut.name})
+
+    if (!this._initCode) {
+      const {from, tokenId} = this._bridgeNftInput
+      const to = this._bridgeNftInput.to ?? from
+
+      logger.debug(`Creating initCode for ${from}, ${to} and ${tokenId}...`)
+
+      this._initCode = await BridgeNft.createInitCode(from, to, tokenId)
+    }
+
+    return this._initCode
+  }
+
+  async bridgeOut(wallet: HolographWallet, destinationChainId?: number): Promise<Transaction> {
+    const logger = this._logger.addContext({functionName: this.bridgeOut.name})
+
+    let toChainId = this.destinationChainId
+    if (destinationChainId) {
+      toChainId = destinationChainId
+      logger.warn(`WARN: destinationChainId (${this.destinationChainId}) is being override.`)
+    }
+
+    const bridgeOutPayload = await this.getInitCode()
+
+    logger.info(`Making bridgeOut request...`)
+
+    logger.debug(
+      {
+        sourceChainId: this.sourceChainId,
+        destinationChainId: toChainId,
+        contractAddress: this.contractAddress,
+        bridgeOutPayload,
+        account: wallet.account,
+      },
+      `bridgeOut request input`,
+    )
+
+    return this._bridgeOut(this.sourceChainId, toChainId, this.contractAddress, bridgeOutPayload, wallet)
+  }
+}

--- a/packages/sdk/src/services/providers.service.ts
+++ b/packages/sdk/src/services/providers.service.ts
@@ -4,6 +4,7 @@ import {Network} from '@holographxyz/networks'
 import {Config} from './config.service'
 import {HolographLogger} from './logger.service'
 import {UnavailableNetworkError} from '../errors/general/unavailable-network.error'
+import {holographToViemChain} from '../utils/transformers'
 
 export class Providers {
   private readonly logger: HolographLogger
@@ -16,7 +17,10 @@ export class Providers {
     this._providers = {}
 
     this._networks.forEach((network: Network) => {
-      this._providers[network.chain] = createPublicClient({transport: http(network.rpc)})
+      this._providers[network.chain] = createPublicClient({
+        transport: http(network.rpc),
+        chain: holographToViemChain(network.chain),
+      })
     })
   }
 

--- a/packages/sdk/src/services/wallet.service.ts
+++ b/packages/sdk/src/services/wallet.service.ts
@@ -130,7 +130,12 @@ export class HolographWallet {
     return walletClient
   }
 
-  async isBalanceSufficientForTx(chainId: number, gasPrice: bigint, gasLimit: bigint, value = 0n): Promise<boolean> {
+  async isBalanceSufficientForTx(
+    chainId: number,
+    gasPrice: bigint,
+    gasLimit: bigint,
+    value = BigInt(0),
+  ): Promise<boolean> {
     const walletBalance = await this.onChain(chainId).getBalance({address: this._account.address})
 
     const totalGas = gasPrice * gasLimit

--- a/packages/sdk/src/services/wallet.service.ts
+++ b/packages/sdk/src/services/wallet.service.ts
@@ -11,6 +11,7 @@ import {
   WalletClient,
   publicActions,
   isAddress,
+  PublicActions,
 } from 'viem'
 import {privateKeyToAccount, mnemonicToAccount, toAccount} from 'viem/accounts'
 import {Network, networks as holographNetworks} from '@holographxyz/networks'
@@ -77,7 +78,7 @@ export class HolographWallet {
   private readonly _logger: HolographLogger
   private _account: HolographAccount
   private _networks?: Network[]
-  private _multiChainWalletClient: Record<number, WalletClient> = {}
+  private _multiChainWalletClient: Record<number, WalletClient & PublicActions> = {}
 
   constructor({account, networks, chainsRpc}: HolographWalletArgs) {
     this._logger = HolographLogger.createLogger({serviceName: HolographWallet.name})
@@ -116,7 +117,7 @@ export class HolographWallet {
     return this._account
   }
 
-  onChain(chainId: number): WalletClient {
+  onChain(chainId: number): WalletClient & PublicActions {
     const logger = this._logger.addContext({functionName: this.onChain.name})
     logger.info(`wallet client accessing chainId = ${chainId}`)
 
@@ -127,6 +128,15 @@ export class HolographWallet {
     }
 
     return walletClient
+  }
+
+  async isBalanceSufficientForTx(chainId: number, gasPrice: bigint, gasLimit: bigint, value = 0n): Promise<boolean> {
+    const walletBalance = await this.onChain(chainId).getBalance({address: this._account.address})
+
+    const totalGas = gasPrice * gasLimit
+    const totalBalanceNeeded = totalGas + value
+
+    return walletBalance > totalBalanceNeeded
   }
 }
 

--- a/packages/sdk/src/tests/assets/bridge-collection.test.ts
+++ b/packages/sdk/src/tests/assets/bridge-collection.test.ts
@@ -72,7 +72,7 @@ describe('Asset class: BridgeCollection', () => {
     it('should be able to bridge a collection', async () => {
       const tx = await bridgeCollection.bridgeOut(destinationChainId)
 
-      console.log('tx: ', tx)
+      console.log('DEBUG| transaction hash: ', tx)
 
       const receipt = await wallet.onChain(sourceChainId).getTransactionReceipt({hash: tx.hash})
       expect(receipt.status).toBe('success')

--- a/packages/sdk/src/tests/assets/bridge-nft.test.ts
+++ b/packages/sdk/src/tests/assets/bridge-nft.test.ts
@@ -7,18 +7,20 @@ import {generateRandomSalt} from '../../utils/helpers'
 import {BridgeCollection} from '../../assets/bridge-collection'
 import {HolographLegacyCollection} from '../../assets/collection-legacy'
 import {configObject, LOCALHOST2_CHAIN_ID, LOCALHOST_CHAIN_ID} from '../setup'
+import {NFT} from '../../assets/nft'
+import {BridgeNft} from '../../assets/bridge-nft'
 
 /**
  * TODO:
  * These tests should be executed on a testnet as they are not expected to run successfully locally.
  */
-describe('Asset class: BridgeCollection', () => {
+describe('Asset class: BridgeNft', () => {
   const account: HolographAccount = configObject.accounts?.default!
   const accountAddress = account?.address
   const wallet = new HolographWallet({account, chainsRpc: configObject.networks})
 
   let collection: HolographLegacyCollection
-  let bridgeCollection: BridgeCollection
+  let bridgeNft: BridgeNft
   let sourceChainId: number
   let destinationChainId: number
   let contractAddress: Address
@@ -40,28 +42,45 @@ describe('Asset class: BridgeCollection', () => {
 
     const signatureData = await collection.signDeploy(wallet)
     const {collectionAddress} = await collection.deploy(signatureData)
-    const erc721DeploymentConfig = await collection['_createErc721DeploymentConfig'](accountAddress)
+
+    const myNft = new NFT({
+      collection,
+      metadata: {
+        name: 'My new NFT',
+        description: 'Probably nothing.',
+        creator: 'Holograph Protocol',
+      },
+      ipfsInfo: {
+        ipfsImageCid: 'QmfPiMDcWQNPmJpZ1MKicVQzoo42Jgb2fYFH7PemhXkM32',
+        ipfsMetadataCid: 'QmfPiMDcWQNPmJpZ1MKicVQzoo42Jgb2fYFH7PemhXkM32/metadata.json',
+      },
+    })
+
+    const {tokenId, txHash} = await myNft.mint({
+      chainId: sourceChainId,
+    })
 
     contractAddress = collectionAddress
 
-    bridgeCollection = new BridgeCollection(configObject, {
+    bridgeNft = new BridgeNft(configObject, {
       sourceChainId,
+      destinationChainId,
       contractAddress,
-      erc721DeploymentConfig,
-      wallet,
+      tokenId,
+      from: accountAddress,
     })
   })
 
-  it('should be able to get the BridgeCollection wrapper class', () => {
+  it('should be able to get the BridgeNft wrapper class', () => {
     expect(BridgeCollection).toHaveProperty('createInitCode')
 
-    expect(bridgeCollection).toHaveProperty('getInitCode')
-    expect(bridgeCollection).toHaveProperty('bridgeOut')
+    expect(bridgeNft).toHaveProperty('getInitCode')
+    expect(bridgeNft).toHaveProperty('bridgeOut')
   })
 
   describe('getInitCode()', () => {
     it('should be able to get the bridge out request init code', async () => {
-      const bridgeOutPayload = await bridgeCollection.getInitCode()
+      const bridgeOutPayload = await bridgeNft.getInitCode()
 
       expectTypeOf(bridgeOutPayload).toBeString()
       expect(bridgeOutPayload.startsWith('0x')).toBeTruthy()
@@ -69,8 +88,8 @@ describe('Asset class: BridgeCollection', () => {
   })
 
   describe.skip('bridgeOut()', () => {
-    it('should be able to bridge a collection', async () => {
-      const tx = await bridgeCollection.bridgeOut(destinationChainId)
+    it('should be able to bridge a NFT', async () => {
+      const tx = await bridgeNft.bridgeOut(wallet)
 
       console.log('tx: ', tx)
 

--- a/packages/sdk/src/tests/assets/bridge-nft.test.ts
+++ b/packages/sdk/src/tests/assets/bridge-nft.test.ts
@@ -91,7 +91,7 @@ describe('Asset class: BridgeNft', () => {
     it('should be able to bridge a NFT', async () => {
       const tx = await bridgeNft.bridgeOut(wallet)
 
-      console.log('tx: ', tx)
+      console.log('DEBUG| transaction hash: ', tx)
 
       const receipt = await wallet.onChain(sourceChainId).getTransactionReceipt({hash: tx.hash})
       expect(receipt.status).toBe('success')

--- a/packages/sdk/src/tests/assets/collection-legacy.test.ts
+++ b/packages/sdk/src/tests/assets/collection-legacy.test.ts
@@ -1,5 +1,5 @@
-import {beforeEach, describe, expect, it} from 'vitest'
-import {isAddress} from 'viem'
+import {beforeAll, beforeEach, describe, expect, it} from 'vitest'
+import {Address, isAddress} from 'viem'
 
 import {HolographLegacyCollection} from '../../assets/collection-legacy'
 import {ContractRevertError} from '../../errors'
@@ -7,6 +7,7 @@ import {HolographWallet} from '../../services'
 import {configObject, localhostContractAddresses, LOCALHOST2_CHAIN_ID} from '../setup'
 import {generateRandomSalt, sleep} from '../../utils/helpers'
 import {HolographAccount} from '../../utils/types'
+import {getErc721DeploymentConfigHash} from '../../utils/encoders'
 
 describe('Asset class: HolographLegacyCollection', () => {
   const account: HolographAccount = configObject.accounts?.default!

--- a/packages/sdk/src/tests/assets/collection-legacy.test.ts
+++ b/packages/sdk/src/tests/assets/collection-legacy.test.ts
@@ -1,5 +1,5 @@
-import {beforeAll, beforeEach, describe, expect, it} from 'vitest'
-import {Address, isAddress} from 'viem'
+import {beforeEach, describe, expect, it} from 'vitest'
+import {isAddress} from 'viem'
 
 import {HolographLegacyCollection} from '../../assets/collection-legacy'
 import {ContractRevertError} from '../../errors'
@@ -7,7 +7,6 @@ import {HolographWallet} from '../../services'
 import {configObject, localhostContractAddresses, LOCALHOST2_CHAIN_ID} from '../setup'
 import {generateRandomSalt, sleep} from '../../utils/helpers'
 import {HolographAccount} from '../../utils/types'
-import {getErc721DeploymentConfigHash} from '../../utils/encoders'
 
 describe('Asset class: HolographLegacyCollection', () => {
   const account: HolographAccount = configObject.accounts?.default!

--- a/packages/sdk/vitest.config.js
+++ b/packages/sdk/vitest.config.js
@@ -1,6 +1,7 @@
 export default {
   test: {
     setupFiles: ['./src/tests/setup.ts'],
-    testTimeout: 30000, // 30 seconds
+    testTimeout: 120000, // 2 min
+    hookTimeout: 120000,
   },
 }


### PR DESCRIPTION
## Describe Changes

Changes made to the package: **sdk**.

I made it better by doing ...

- add bridge nft class and tests
- add function `isBalanceSufficientForTx` to the `HolographWallet` class
- Change Providers class to include the `chain` property into the publicClient instances

PS.: The bridge tests do not run on localhost. To run them, you need to update the .env file to `HOLOGRAPH_ENVIRONMENT=localhost` and configure the `setup.ts `file with the correct settings to run on a testnet.

 Bridge NFT  tests on develop:
![image](https://github.com/holographxyz/holograph/assets/37748828/1256861a-e1dd-42ec-8807-6805a8c544c9)
example tx: https://sepolia.etherscan.io/tx/0xc6dc12787e5948888639a667284b25ac85391f31a4884622541508de76f0396f

Tests on localhost (only the bridge tests fail):
![image](https://github.com/holographxyz/holograph/assets/37748828/57867fd6-24cd-45e3-a17e-c0533b548928)



## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] All tests are passing
